### PR TITLE
Added Player Death on collision with Mob

### DIFF
--- a/squash_the_creeps_start_1.1.0/.godot/editor/create_recent.Node
+++ b/squash_the_creeps_start_1.1.0/.godot/editor/create_recent.Node
@@ -1,10 +1,11 @@
+CollisionShape3D
+Area3D
 Timer
 PathFollow3D
 Path3D
 MeshInstance3D
 Node3D
 VisibleOnScreenNotifier3D
-CollisionShape3D
 CharacterBody3D
 Camera3D
 Marker3D

--- a/squash_the_creeps_start_1.1.0/.godot/editor/editor_layout.cfg
+++ b/squash_the_creeps_start_1.1.0/.godot/editor/editor_layout.cfg
@@ -28,16 +28,16 @@ dock_4="Inspector,Node"
 [EditorNode]
 
 open_scenes=PackedStringArray("res://main.tscn", "res://player.tscn", "res://mob.tscn")
-current_scene="res://mob.tscn"
+current_scene="res://main.tscn"
 center_split_offset=-252
 selected_default_debugger_tab_idx=0
 selected_main_editor_idx=2
-selected_bottom_panel_item=0
+selected_bottom_panel_item=1
 
 [ScriptEditor]
 
 open_scripts=["res://main.gd", "res://Mob.gd", "res://player.gd"]
-selected_script="res://Mob.gd"
+selected_script="res://main.gd"
 open_help=[]
 script_split_offset=70
 list_split_offset=0

--- a/squash_the_creeps_start_1.1.0/.godot/editor/filesystem_update4
+++ b/squash_the_creeps_start_1.1.0/.godot/editor/filesystem_update4
@@ -3,3 +3,4 @@ res://player.tscn
 res://player.gd
 res://Mob.gd
 res://main.tscn
+res://main.gd

--- a/squash_the_creeps_start_1.1.0/.godot/editor/main.tscn-editstate-3070c538c03ee49b7677ff960a3f5195.cfg
+++ b/squash_the_creeps_start_1.1.0/.godot/editor/main.tscn-editstate-3070c538c03ee49b7677ff960a3f5195.cfg
@@ -173,4 +173,4 @@ Anim={
 "zfar": 4000.01,
 "znear": 0.05
 }
-selected_nodes=Array[NodePath]([NodePath("/root/@EditorNode@17147/@Panel@13/@VBoxContainer@14/@HSplitContainer@17/@HSplitContainer@25/@HSplitContainer@33/@VBoxContainer@34/@VSplitContainer@36/@VSplitContainer@62/@VBoxContainer@63/@PanelContainer@110/MainScreen/@CanvasItemEditor@9462/@VSplitContainer@9281/@HSplitContainer@9283/@HSplitContainer@9285/@Control@9286/@SubViewportContainer@9287/@SubViewport@9288/Mob")])
+selected_nodes=Array[NodePath]([NodePath("/root/@EditorNode@17147/@Panel@13/@VBoxContainer@14/@HSplitContainer@17/@HSplitContainer@25/@HSplitContainer@33/@VBoxContainer@34/@VSplitContainer@36/@VSplitContainer@62/@VBoxContainer@63/@PanelContainer@110/MainScreen/@CanvasItemEditor@9462/@VSplitContainer@9281/@HSplitContainer@9283/@HSplitContainer@9285/@Control@9286/@SubViewportContainer@9287/@SubViewport@9288/Main/Player")])

--- a/squash_the_creeps_start_1.1.0/.godot/editor/mob.tscn-editstate-5b94865898bd9b5cb44e426bf42f6f48.cfg
+++ b/squash_the_creeps_start_1.1.0/.godot/editor/mob.tscn-editstate-5b94865898bd9b5cb44e426bf42f6f48.cfg
@@ -172,4 +172,4 @@ Anim={
 "zfar": 4000.01,
 "znear": 0.05
 }
-selected_nodes=Array[NodePath]([NodePath("/root/@EditorNode@17147/@Panel@13/@VBoxContainer@14/@HSplitContainer@17/@HSplitContainer@25/@HSplitContainer@33/@VBoxContainer@34/@VSplitContainer@36/@VSplitContainer@62/@VBoxContainer@63/@PanelContainer@110/MainScreen/@CanvasItemEditor@9462/@VSplitContainer@9281/@HSplitContainer@9283/@HSplitContainer@9285/@Control@9286/@SubViewportContainer@9287/@SubViewport@9288/Mob")])
+selected_nodes=Array[NodePath]([NodePath("/root/@EditorNode@17147/@Panel@13/@VBoxContainer@14/@HSplitContainer@17/@HSplitContainer@25/@HSplitContainer@33/@VBoxContainer@34/@VSplitContainer@36/@VSplitContainer@62/@VBoxContainer@63/@PanelContainer@110/MainScreen/@CanvasItemEditor@9462/@VSplitContainer@9281/@HSplitContainer@9283/@HSplitContainer@9285/@Control@9286/@SubViewportContainer@9287/@SubViewport@9288/Main/Player")])

--- a/squash_the_creeps_start_1.1.0/.godot/editor/player.tscn-editstate-36a25e342948d0ceacc500772b5412b3.cfg
+++ b/squash_the_creeps_start_1.1.0/.godot/editor/player.tscn-editstate-36a25e342948d0ceacc500772b5412b3.cfg
@@ -106,11 +106,11 @@ Anim={
 "listener": true,
 "lock_rotation": false,
 "orthogonal": false,
-"position": Vector3(0.702971, 3.66175, 1.07928),
+"position": Vector3(1.70611, 1.15498, -0.694071),
 "use_environment": false,
 "view_type": 0,
-"x_rotation": 0.895278,
-"y_rotation": 0.298484
+"x_rotation": 0.572389,
+"y_rotation": -0.504369
 }, {
 "auto_orthogonal": false,
 "auto_orthogonal_enabled": true,
@@ -172,4 +172,4 @@ Anim={
 "zfar": 4000.01,
 "znear": 0.05
 }
-selected_nodes=Array[NodePath]([NodePath("/root/@EditorNode@17147/@Panel@13/@VBoxContainer@14/@HSplitContainer@17/@HSplitContainer@25/@HSplitContainer@33/@VBoxContainer@34/@VSplitContainer@36/@VSplitContainer@62/@VBoxContainer@63/@PanelContainer@110/MainScreen/@CanvasItemEditor@9462/@VSplitContainer@9281/@HSplitContainer@9283/@HSplitContainer@9285/@Control@9286/@SubViewportContainer@9287/@SubViewport@9288/Mob")])
+selected_nodes=Array[NodePath]([NodePath("/root/@EditorNode@17147/@Panel@13/@VBoxContainer@14/@HSplitContainer@17/@HSplitContainer@25/@HSplitContainer@33/@VBoxContainer@34/@VSplitContainer@36/@VSplitContainer@62/@VBoxContainer@63/@PanelContainer@110/MainScreen/@CanvasItemEditor@9462/@VSplitContainer@9281/@HSplitContainer@9283/@HSplitContainer@9285/@Control@9286/@SubViewportContainer@9287/@SubViewport@9288/Main/Player")])

--- a/squash_the_creeps_start_1.1.0/.godot/editor/player.tscn-folding-36a25e342948d0ceacc500772b5412b3.cfg
+++ b/squash_the_creeps_start_1.1.0/.godot/editor/player.tscn-folding-36a25e342948d0ceacc500772b5412b3.cfg
@@ -1,5 +1,5 @@
 [folding]
 
-node_unfolds=[NodePath("."), PackedStringArray("Collision")]
-resource_unfolds=["res://player.tscn::SphereShape3D_3v5sg", PackedStringArray()]
+node_unfolds=[NodePath("."), PackedStringArray("Collision"), NodePath("MobDetector"), PackedStringArray("Collision")]
+resource_unfolds=["res://player.tscn::SphereShape3D_3v5sg", PackedStringArray(), "res://player.tscn::CylinderShape3D_oogjr", PackedStringArray()]
 nodes_folded=[]

--- a/squash_the_creeps_start_1.1.0/.godot/editor/project_metadata.cfg
+++ b/squash_the_creeps_start_1.1.0/.godot/editor/project_metadata.cfg
@@ -34,6 +34,7 @@ StandardMaterial3D:uv1_scale=true
 StandardMaterial3D:uv2_scale=true
 Path3D:scale=true
 PathFollow3D:scale=true
+Area3D:scale=true
 
 [script_setup]
 

--- a/squash_the_creeps_start_1.1.0/.godot/editor/script_editor_cache.cfg
+++ b/squash_the_creeps_start_1.1.0/.godot/editor/script_editor_cache.cfg
@@ -3,11 +3,11 @@
 state={
 "bookmarks": PackedInt32Array(),
 "breakpoints": PackedInt32Array(),
-"column": 16,
+"column": 6,
 "folded_lines": Array[int]([]),
 "h_scroll_position": 0,
-"row": 60,
-"scroll_position": 3.0,
+"row": 77,
+"scroll_position": 55.0,
 "selection": false,
 "syntax_highlighter": "GDScript"
 }
@@ -21,7 +21,7 @@ state={
 "folded_lines": Array[int]([]),
 "h_scroll_position": 0,
 "row": 36,
-"scroll_position": 13.0,
+"scroll_position": 14.0,
 "selection": false,
 "syntax_highlighter": "GDScript"
 }
@@ -31,11 +31,11 @@ state={
 state={
 "bookmarks": PackedInt32Array(),
 "breakpoints": PackedInt32Array(),
-"column": 5,
+"column": 17,
 "folded_lines": Array[int]([]),
 "h_scroll_position": 0,
-"row": 11,
-"scroll_position": 0.0,
+"row": 32,
+"scroll_position": 11.0,
 "selection": false,
 "syntax_highlighter": "GDScript"
 }

--- a/squash_the_creeps_start_1.1.0/main.gd
+++ b/squash_the_creeps_start_1.1.0/main.gd
@@ -27,3 +27,7 @@ func _on_mob_timer_timeout():
 	
 	#Spawn the mob by adding it to the Main scene
 	add_child(mob)
+
+
+func _on_player_hit():
+	$MobTimer.stop()

--- a/squash_the_creeps_start_1.1.0/main.tscn
+++ b/squash_the_creeps_start_1.1.0/main.tscn
@@ -80,4 +80,5 @@ transform = Transform3D(-1, 0, -8.74228e-08, 0, 1, 0, 8.74228e-08, 0, -1, -14.03
 wait_time = 0.5
 autostart = true
 
+[connection signal="hit" from="Player" to="." method="_on_player_hit"]
 [connection signal="timeout" from="MobTimer" to="." method="_on_mob_timer_timeout"]

--- a/squash_the_creeps_start_1.1.0/player.gd
+++ b/squash_the_creeps_start_1.1.0/player.gd
@@ -9,6 +9,9 @@ extends CharacterBody3D
 #meters per second
 @export var bounce_impulse = 16
 
+#Emitted when the player was hit by a mob
+signal hit
+
 var target_velocity = Vector3.ZERO
 
 func _physics_process(delta):
@@ -66,3 +69,10 @@ func _physics_process(delta):
 	#Moving the Character
 	velocity = target_velocity
 	move_and_slide()
+
+func die():
+	hit.emit()
+	queue_free()
+
+func _on_mob_detector_body_entered(body):
+	die()

--- a/squash_the_creeps_start_1.1.0/player.tscn
+++ b/squash_the_creeps_start_1.1.0/player.tscn
@@ -1,10 +1,14 @@
-[gd_scene load_steps=4 format=3 uid="uid://b8076c0by485y"]
+[gd_scene load_steps=5 format=3 uid="uid://b8076c0by485y"]
 
 [ext_resource type="Script" path="res://player.gd" id="1_te8di"]
 [ext_resource type="PackedScene" uid="uid://c58tdrsqdknqo" path="res://art/player.glb" id="1_xllny"]
 
 [sub_resource type="SphereShape3D" id="SphereShape3D_3v5sg"]
 radius = 0.791691
+
+[sub_resource type="CylinderShape3D" id="CylinderShape3D_oogjr"]
+height = 0.136118
+radius = 1.18126
 
 [node name="Player" type="CharacterBody3D"]
 collision_mask = 6
@@ -17,3 +21,14 @@ script = ExtResource("1_te8di")
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.812617, 0)
 shape = SubResource("SphereShape3D_3v5sg")
+
+[node name="MobDetector" type="Area3D" parent="."]
+collision_layer = 0
+collision_mask = 2
+monitorable = false
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="MobDetector"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.377275, 0)
+shape = SubResource("CylinderShape3D_oogjr")
+
+[connection signal="body_entered" from="MobDetector" to="." method="_on_mob_detector_body_entered"]


### PR DESCRIPTION
Checks for collision with a mob. The player character is removed from the screen and the mob timer stops. Remaining mobs on screen will float off.